### PR TITLE
Add USI Konstruction Ports

### DIFF
--- a/patches/USI/largeKonstructionPort.cfg
+++ b/patches/USI/largeKonstructionPort.cfg
@@ -1,0 +1,110 @@
+// Adds LED indicators to the ;arge docking port.
+
+@PART[ConstructionPort2] {
+	@description ^= :(.)$:$0 Indicator lights display crossfeed status.:
+
+	// We have to re-specify the model for the stock part, because this is
+	// an older part that uses the "mesh =" syntax in its .cfg file instead
+	// of the newer "MODEL" syntax. The "mesh =" syntax doesn't allow having
+	// multiple models as part of the same part, which would prevent this mod
+	// from adding meshes for the indicator lights.
+	MODEL
+	{
+		model = UmbraSpaceIndustries/Konstruction/Parts/ConstructionPort2/model
+	}
+
+	//-------------------------------------------------------------------------
+	// INDICATOR MESHES
+	//-------------------------------------------------------------------------
+	MODEL
+	{
+		model = IndicatorLights/Meshes/squareLamp2
+		scale = 0.3, 1, 2
+		position = 0, 0.156, -0.585
+		rotation = 0, 0, 0
+	}
+	MODEL
+	{
+		model = IndicatorLights/Meshes/squareLamp2
+		scale = 0.3, 1, 2
+		position = 0.507, 0.156, 0.2925
+		rotation = 0, -120, 0
+	}
+	MODEL
+	{
+		model = IndicatorLights/Meshes/squareLamp2
+		scale = 0.3, 1, 2
+		position = -0.507, 0.156, 0.2925
+		rotation = 0, 120, 0
+	}
+
+	MODEL
+	{
+		model = IndicatorLights/Meshes/squareLamp
+		scale = 0.3, 1.6, 1
+		position = 0, 0.1, -1.25
+		rotation = 0, 180, 0
+	}
+	MODEL
+	{
+		model = IndicatorLights/Meshes/squareLamp
+		scale = 0.3, 1.6, 1
+		position = 1.083, 0.1, 0.625
+		rotation = 0, 300, 0
+	}
+	MODEL
+	{
+		model = IndicatorLights/Meshes/squareLamp
+		scale = 0.3, 1.6, 1
+		position = -1.083, 0.1, 0.625
+		rotation = 0, 60, 0
+	}
+
+
+	//-------------------------------------------------------------------------
+	// CONTROLLABLE EMISSIVES
+	//-------------------------------------------------------------------------
+	MODULE {
+		name = ModuleControllableEmissive
+		target = IndicatorLights/Meshes/squareLamp
+		emissiveName = indicator
+	}
+
+	MODULE {
+		name = ModuleControllableEmissive
+		target = IndicatorLights/Meshes/squareLamp2
+		emissiveName = indicator
+	}
+
+	//-------------------------------------------------------------------------
+	// CONTROLLERS
+	//-------------------------------------------------------------------------
+
+	// Controls the light manually.
+	MODULE {
+		name = ModuleToggleLED
+		activeColor = ModuleDockingCrossfeedIndicator
+		inactiveColor = $Off
+		defaultActionGroup = Light
+	}
+
+	// This provides detection of the docking port crossfeed. We don't specify an
+	// emissiveName here because it's not controlling the light directly (we're
+	// just using it as an input to other modules).
+	MODULE {
+		name = ModuleDockingCrossfeedIndicator
+	}
+
+	// This detects the docking state. We make this the "root" controller that
+	// actually drives the emissive color, because we want the indicator to blink
+	// when it's acquiring or disengaging, regardless of the toggle setting.
+	// If we're in the "ready" (or docked) state, then we'll take our input
+	// from the toggle.
+	MODULE {
+		name = ModuleDockingStateIndicator
+		emissiveName = indicator
+		readyColor = ModuleToggleLED
+		acquireColor = blink(ModuleDockingCrossfeedIndicator, 100, $Off, 100)
+		disengageColor = blink(ModuleDockingCrossfeedIndicator, 120, $Off, 1080)
+	}
+}

--- a/patches/USI/largeKonstructionPort.cfg
+++ b/patches/USI/largeKonstructionPort.cfg
@@ -1,4 +1,4 @@
-// Adds LED indicators to the large docking port.
+// Adds LED indicators to the ;arge docking port.
 
 @PART[ConstructionPort2] {
 	@description ^= :(.)$:$0 Indicator lights display crossfeed status.:
@@ -61,20 +61,52 @@
 	}
 
 
+// Snap
+
+	MODEL
+	{
+		model = IndicatorLights/Meshes/squareLamp2
+		scale = 0.3, 1, 2
+		position = 0, 0.156, 0.585
+		rotation = 0, 0, 0
+	}
+
+	MODEL
+	{
+		model = IndicatorLights/Meshes/squareLamp
+		scale = 0.3, 1.6, 1
+		position = 0, 0.1, 1.25
+		rotation = 0, 180, 0
+	}
+
+
 	//-------------------------------------------------------------------------
 	// CONTROLLABLE EMISSIVES
 	//-------------------------------------------------------------------------
 	MODULE {
 		name = ModuleControllableEmissive
-		target = IndicatorLights/Meshes/squareLamp
+		target = IndicatorLights/Meshes/squareLamp:0,1,2
 		emissiveName = indicator
 	}
 
 	MODULE {
 		name = ModuleControllableEmissive
-		target = IndicatorLights/Meshes/squareLamp2
+		target = IndicatorLights/Meshes/squareLamp2:0,1,2
 		emissiveName = indicator
 	}
+
+	MODULE {
+		name = ModuleControllableEmissive
+		target = IndicatorLights/Meshes/squareLamp:3
+		emissiveName = snap
+	}
+
+	MODULE {
+		name = ModuleControllableEmissive
+		target = IndicatorLights/Meshes/squareLamp2:3
+		emissiveName = snap
+	}
+
 
 	//-------------------------------------------------------------------------
 	// CONTROLLERS
@@ -107,4 +139,12 @@
 		acquireColor = blink(ModuleDockingCrossfeedIndicator, 100, $Off, 100)
 		disengageColor = blink(ModuleDockingCrossfeedIndicator, 120, $Off, 1080)
 	}
+
+	MODULE {
+        name = ModuleBooleanIndicator
+		input = portSnap@ModuleWeldablePort
+		activeColor = $Warning
+		emissiveName = snap
+	}
+
 }

--- a/patches/USI/largeKonstructionPort.cfg
+++ b/patches/USI/largeKonstructionPort.cfg
@@ -1,4 +1,4 @@
-// Adds LED indicators to the ;arge docking port.
+// Adds LED indicators to the large docking port.
 
 @PART[ConstructionPort2] {
 	@description ^= :(.)$:$0 Indicator lights display crossfeed status.:

--- a/patches/USI/mediumKonstructionPort.cfg
+++ b/patches/USI/mediumKonstructionPort.cfg
@@ -48,14 +48,45 @@
 		rotation = 20, 0, 0
 	}
 
+//Snap
+
+	MODEL
+	{
+		model = IndicatorLights/Meshes/squareLamp2
+		scale = 0.3, 1, 1
+		position = 0.43, 0.28, 0
+		rotation = 0, 0, 0
+	}
+
+	MODEL
+	{
+		model = IndicatorLights/Meshes/squareLamp2
+		scale = 0.3, 1, 1
+		position = -0.43, 0.28, 0
+		rotation = 0, 0, 0
+	}
+
+	MODEL
+	{
+		model = IndicatorLights/Meshes/squareLamp2
+		scale = 1, 1, 0.3
+		position = 0, 0.28, 0.43
+		rotation = 0, 0, 0
+	}
 
 	//-------------------------------------------------------------------------
 	// CONTROLLABLE EMISSIVES
 	//-------------------------------------------------------------------------
 	MODULE {
 		name = ModuleControllableEmissive
-		target = IndicatorLights/Meshes/squareLamp2
+		target = IndicatorLights/Meshes/squareLamp2:0,1,2,3
 		emissiveName = indicator
+	}
+
+	MODULE {
+		name = ModuleControllableEmissive
+		target = IndicatorLights/Meshes/squareLamp2:4,5,6
+		emissiveName = snap
 	}
 
 
@@ -90,4 +121,12 @@
 		acquireColor = blink(ModuleDockingCrossfeedIndicator, 100, $Off, 100)
 		disengageColor = blink(ModuleDockingCrossfeedIndicator, 120, $Off, 1080)
 	}
+
+	MODULE {
+        name = ModuleBooleanIndicator
+		input = portSnap@ModuleWeldablePort
+		activeColor = $Warning
+		emissiveName = snap
+	}
+
 }

--- a/patches/USI/mediumKonstructionPort.cfg
+++ b/patches/USI/mediumKonstructionPort.cfg
@@ -1,0 +1,93 @@
+// Adds LED indicators to the medium docking port.
+
+@PART[ConstructionPort1] {
+	@description ^= :(.)$:$0 Indicator lights display crossfeed status.:
+
+	// We have to re-specify the model for the stock part, because this is
+	// an older part that uses the "mesh =" syntax in its .cfg file instead
+	// of the newer "MODEL" syntax. The "mesh =" syntax doesn't allow having
+	// multiple models as part of the same part, which would prevent this mod
+	// from adding meshes for the indicator lights.
+	MODEL
+	{
+		model = UmbraSpaceIndustries/Konstruction/Parts/ConstructionPort1/model
+	}
+
+	//-------------------------------------------------------------------------
+	// INDICATOR MESHES
+	//-------------------------------------------------------------------------
+	MODEL
+	{
+		model = IndicatorLights/Meshes/squareLamp2
+		scale = 1, 1, 0.3
+		position = -0.5331, 0.08, 0
+		rotation = 0, 0, 20
+	}
+
+	MODEL
+	{
+		model = IndicatorLights/Meshes/squareLamp2
+		scale = 1, 1, 0.3
+		position = 0.5331, 0.08, 0
+		rotation = 0, 0, -20
+	}
+
+	MODEL
+	{
+		model = IndicatorLights/Meshes/squareLamp2
+		scale = 0.3, 1, 1
+		position = 0, 0.08, -0.5331
+		rotation = -20, 0, 0
+	}
+
+	MODEL
+	{
+		model = IndicatorLights/Meshes/squareLamp2
+		scale = 0.3, 1, 1
+		position = 0, 0.08, 0.5331
+		rotation = 20, 0, 0
+	}
+
+
+	//-------------------------------------------------------------------------
+	// CONTROLLABLE EMISSIVES
+	//-------------------------------------------------------------------------
+	MODULE {
+		name = ModuleControllableEmissive
+		target = IndicatorLights/Meshes/squareLamp2
+		emissiveName = indicator
+	}
+
+
+	//-------------------------------------------------------------------------
+	// CONTROLLERS
+	//-------------------------------------------------------------------------
+
+	// Controls the light manually.
+	MODULE {
+		name = ModuleToggleLED
+		activeColor = ModuleDockingCrossfeedIndicator
+		inactiveColor = $Off
+		defaultActionGroup = Light
+	}
+
+	// This provides detection of the docking port state. We don't specify an
+	// emissiveName here because it's not controlling the light directly (we're
+	// just using it as an input to other modules).
+	MODULE {
+		name = ModuleDockingCrossfeedIndicator
+	}
+
+	// This detects the docking state. We make this the "root" controller that
+	// actually drives the emissive color, because we want the indicator to blink
+	// when it's acquiring or disengaging, regardless of the toggle setting.
+	// If we're in the "ready" (or docked) state, then we'll take our input
+	// from the toggle.
+	MODULE {
+		name = ModuleDockingStateIndicator
+		emissiveName = indicator
+		readyColor = ModuleToggleLED
+		acquireColor = blink(ModuleDockingCrossfeedIndicator, 100, $Off, 100)
+		disengageColor = blink(ModuleDockingCrossfeedIndicator, 120, $Off, 1080)
+	}
+}

--- a/patches/USI/smallKonstructionPort.cfg
+++ b/patches/USI/smallKonstructionPort.cfg
@@ -32,14 +32,27 @@
 		rotation = 0, 0, -8
 	}
 
+	MODEL
+	{
+		model = IndicatorLights/Meshes/squareLamp2
+		scale = 0.3, 0.6, 0.3
+		position = 0.0, 0.06, 0.32
+		rotation = 0, 0, 0
+	}
 
 	//-------------------------------------------------------------------------
 	// CONTROLLABLE EMISSIVES
 	//-------------------------------------------------------------------------
 	MODULE {
 		name = ModuleControllableEmissive
-		target = IndicatorLights/Meshes/squareLamp2
+		target = IndicatorLights/Meshes/squareLamp2:0,1
 		emissiveName = indicator
+	}
+
+	MODULE {
+		name = ModuleControllableEmissive
+		target = IndicatorLights/Meshes/squareLamp2:2
+		emissiveName = snap
 	}
 
 
@@ -74,4 +87,13 @@
 		acquireColor = blink(ModuleDockingCrossfeedIndicator, 100, $Off, 100)
 		disengageColor = blink(ModuleDockingCrossfeedIndicator, 120, $Off, 1080)
 	}
+
+    MODULE {
+        name = ModuleBooleanIndicator
+		input = portSnap@ModuleWeldablePort
+		activeColor = $Warning
+		emissiveName = snap
+	}
+
+
 }

--- a/patches/USI/smallKonstructionPort.cfg
+++ b/patches/USI/smallKonstructionPort.cfg
@@ -1,0 +1,77 @@
+// Adds LED indicators to the small docking port.
+
+@PART[ConstructionPort0] {
+	@description ^= :(.)$:$0 Indicator lights display crossfeed status.:
+
+	// We have to re-specify the model for the stock part, because this is
+	// an older part that uses the "mesh =" syntax in its .cfg file instead
+	// of the newer "MODEL" syntax. The "mesh =" syntax doesn't allow having
+	// multiple models as part of the same part, which would prevent this mod
+	// from adding meshes for the indicator lights.
+	MODEL
+	{
+		model = UmbraSpaceIndustries/Konstruction/Parts/ConstructionPort0/model
+	}
+
+	//-------------------------------------------------------------------------
+	// INDICATOR MESHES
+	//-------------------------------------------------------------------------
+	MODEL
+	{
+		model = IndicatorLights/Meshes/squareLamp2
+		scale = 0.3, 0.6, 0.3
+		position = -0.32, 0.06, 0
+		rotation = 0, 0, 8
+	}
+
+	MODEL
+	{
+		model = IndicatorLights/Meshes/squareLamp2
+		scale = 0.3, 0.6, 0.3
+		position = 0.32, 0.06, 0
+		rotation = 0, 0, -8
+	}
+
+
+	//-------------------------------------------------------------------------
+	// CONTROLLABLE EMISSIVES
+	//-------------------------------------------------------------------------
+	MODULE {
+		name = ModuleControllableEmissive
+		target = IndicatorLights/Meshes/squareLamp2
+		emissiveName = indicator
+	}
+
+
+	//-------------------------------------------------------------------------
+	// CONTROLLERS
+	//-------------------------------------------------------------------------
+
+	// Controls the light manually.
+	MODULE {
+		name = ModuleToggleLED
+		activeColor = ModuleDockingCrossfeedIndicator
+		inactiveColor = $Off
+		defaultActionGroup = Light
+	}
+
+	// This provides detection of the docking port state. We don't specify an
+	// emissiveName here because it's not controlling the light directly (we're
+	// just using it as an input to other modules).
+	MODULE {
+		name = ModuleDockingCrossfeedIndicator
+	}
+
+	// This detects the docking state. We make this the "root" controller that
+	// actually drives the emissive color, because we want the indicator to blink
+	// when it's acquiring or disengaging, regardless of the toggle setting.
+	// If we're in the "ready" (or docked) state, then we'll take our input
+	// from the toggle.
+	MODULE {
+		name = ModuleDockingStateIndicator
+		emissiveName = indicator
+		readyColor = ModuleToggleLED
+		acquireColor = blink(ModuleDockingCrossfeedIndicator, 100, $Off, 100)
+		disengageColor = blink(ModuleDockingCrossfeedIndicator, 120, $Off, 1080)
+	}
+}


### PR DESCRIPTION
Basic support: Just copying over stock.

Put them in a 'USI' folder, in hopes that more USI patches will come, and because then they are closer to the stock ports patch config structure.

Note that there are *two* lines changed in per file from the stock ports patch: The part name, and the part model.  (As - like with the stock part - it uses the older 'mesh' syntax.)