### PR TITLE
Changed IndicatorLights_ReStock.cfg to not rescale Small Radial Battery

### DIFF
--- a/patches/IndicatorLights_ReStock.cfg
+++ b/patches/IndicatorLights_ReStock.cfg
@@ -186,14 +186,14 @@
 	{
 		model = ReStock/Assets/Electrical/restock-battery-radial-small-1
 		position = 0.0, 0.0, 0.0
-		scale = 0.5, 0.5, 0.5
+		scale = 1,1,1
 		rotation = 0, 0, 0
 	}
 	MODEL
 	{
 		model = IndicatorLights/Meshes/z100lamp
-		scale = 0.35, 0.35, 0.35
-		position = 0.021, 0.106, -0.05
+		scale = 0.7, 0.7, 0.7
+		position = 0.042, 0.212, -0.1
 		rotation = 270, 0, 0
 	}
 }


### PR DESCRIPTION
Fixed issue where the small radial battery was being set to 50% scale in the ReStock, the scale has been reset to 1 and the indicator light's scale and position updated.