### PR TITLE
Fix the path to the ReStock Science Box model.

### DIFF
--- a/patches/IndicatorLights_ReStock.cfg
+++ b/patches/IndicatorLights_ReStock.cfg
@@ -854,7 +854,7 @@
 	-MODEL,* {}
 	MODEL
 	{
-		model = ReStock/Assets/Science/restock-sciencebox-radial
+		model = ReStock/Assets/Science/restock-sciencebox-radial-1
 	}
 	MODEL
 	{


### PR DESCRIPTION
Amended the model path to the ReStock Science Box model so that is appears correctly in game.