### PR TITLE
Fix Restock relay antennas that change variants

### DIFF
--- a/patches/IndicatorLights_ReStock.cfg
+++ b/patches/IndicatorLights_ReStock.cfg
@@ -6,8 +6,49 @@
 //---------------------------------------------------------------------------//
 // Antennas                                                                  //
 //---------------------------------------------------------------------------//
-// RA-2 Relay Antenna, RA-15 Relay Antenna, RA-100 Relay Antenna:
-// No indicator lights for these parts, as they have variants with different height models.
+// RA-2, RA-15 and RA-100 Relay Antennas have model variants that change
+// the position of the feed horn.  The IL position is a compromise that
+// is designed to be visible in both positions.
+
+// RA-2 Relay Antenna
+@PART[RelayAntenna5]:AFTER[ReStock]:NEEDS[IndicatorLights]
+{
+	!MODEL:HAS[#model[IndicatorLights/Meshes/nubbinLamp]],* { }
+	MODEL
+	{
+		model = IndicatorLights/Meshes/nubbinLamp
+		position = 0, .38, 0
+		scale = 2.0, 2.0, 1
+		rotation = -90, 0, 0
+	}
+}
+
+// RA-15 Relay Antenna
+@PART[RelayAntenna50]:AFTER[ReStock]:NEEDS[IndicatorLights]
+{
+	!MODEL:HAS[#model[IndicatorLights/Meshes/nubbinLamp]],* { }
+	MODEL
+	{
+		model = IndicatorLights/Meshes/nubbinLamp
+		position = 0, 1.125, 0
+		scale = 2, 2, 2.5
+		rotation = -90, 0, 0
+	}
+}
+
+// RA-100 Relay Antenna
+@PART[RelayAntenna100]:AFTER[ReStock]:NEEDS[IndicatorLights]
+{
+	!MODEL:HAS[#model[IndicatorLights/Meshes/nubbinLamp]],* { }
+	MODEL
+	{
+		model = IndicatorLights/Meshes/nubbinLamp
+		position = 0, 1.18, 0
+		scale = 1.5, 1.5, 5
+		rotation = -90, 0, 0
+	}
+
+}
 
 // Communotron 16
 @PART[longAntenna]:AFTER[ReStock]:NEEDS[IndicatorLights]


### PR DESCRIPTION
Fix for relay antennas that change variants and move the position of the feed horn.  The indicator light is visible in both positions.