### PR TITLE
Docking port lights indicate orientation

### DIFF
--- a/patches/IndicatorLights_DockingPortDirection.cfg
+++ b/patches/IndicatorLights_DockingPortDirection.cfg
@@ -14,7 +14,9 @@
 	// Enough changes are made that it's simplest to delete
 	// old indicators on face and add new indicators
 	//-------------------------------------------------------------------------
-	-MODEL[*squareLamp2]
+	-MODEL,3 {}
+	-MODEL,2 {}
+	-MODEL,1 {}
 	MODEL
 	{
 		model = IndicatorLights/Meshes/squareLamp2

--- a/patches/IndicatorLights_DockingPortDirection.cfg
+++ b/patches/IndicatorLights_DockingPortDirection.cfg
@@ -1,0 +1,85 @@
+//
+// This patch shifts existing indicators and adds new ones
+// to give a indication of an "UP" direction for the docking 
+// ports. 
+//
+// ReStock ports are handled in the ReStock IL patch.  
+//
+// Only runs these if ReStock is not installed. The :AFTER
+// Adds a dependency on IL so the patch will only run if 
+// the base IL mod is installed.
+@PART[dockingPortLarge]:NEEDS[!ReStock]:AFTER[IndicatorLights]
+{
+	//-------------------------------------------------------------------------
+	// Enough changes are made that it's simplest to delete
+	// old indicators on face and add new indicators
+	//-------------------------------------------------------------------------
+	-MODEL[*squareLamp2]
+	MODEL
+	{
+		model = IndicatorLights/Meshes/squareLamp2
+		scale = 0.3, 1, 2
+		position = 0, 0.156, 0.585
+		rotation = 0, 0, 0
+	}
+	MODEL
+	{
+		model = IndicatorLights/Meshes/squareLamp2
+		scale = 0.3, 1, 3
+		position = 0, 0.156, -0.585
+		rotation = 0, 0, 0
+	}
+	MODEL
+	{
+		model = IndicatorLights/Meshes/squareLamp2
+		scale = 0.3, 1, 2
+		position = 0.507, 0.156, 0.2925
+		rotation = 0, 60, 0
+	}
+	MODEL
+	{
+		model = IndicatorLights/Meshes/squareLamp2
+		scale = 0.3, 1, 2
+		position = -0.507, 0.156, 0.2925
+		rotation = 0, -60, 0
+	}
+}
+@PART[dockingPort2]:NEEDS[!ReStock]:AFTER[IndicatorLights]
+{
+	//-------------------------------------------------------------------------
+	// Rotate existing  indicators for left and right down from original position
+	//-------------------------------------------------------------------------
+	@MODEL,1 
+	{
+		@position = -0.37696, 0.08, 0.37696
+		@rotation = 0, 46.5, 20
+	}
+
+	@MODEL,2
+	{
+		@position = 0.37696, 0.08, 0.37696
+		@rotation = 0, -46.5, -20
+	}
+
+}
+@PART[dockingPort3]:NEEDS[!ReStock]:AFTER[IndicatorLights]
+{
+	//-------------------------------------------------------------------------
+	// Add top indicators side indicators are fine
+	//-------------------------------------------------------------------------
+
+	MODEL
+	{
+		model = IndicatorLights/Meshes/squareLamp2
+		scale = 0.3, 0.6, 0.6
+		position = 0.0, 0.065, -0.30
+		rotation = -8, 0, 0
+	}
+	MODEL
+	{
+		model = IndicatorLights/Meshes/squareLamp2
+		scale = 1.2, 0.6, 0.3
+		position = 0.0, 0.07, -0.29
+		rotation = -30, 0, 0
+	}
+}

--- a/patches/IndicatorLights_ReStock.cfg
+++ b/patches/IndicatorLights_ReStock.cfg
@@ -6,12 +6,55 @@
 //---------------------------------------------------------------------------//
 // Antennas                                                                  //
 //---------------------------------------------------------------------------//
-// RA-2 Relay Antenna, RA-15 Relay Antenna, RA-100 Relay Antenna:
-// No indicator lights for these parts, as they have variants with different height models.
+// RA-2, RA-15 and RA-100 Relay Antennas have model variants that change
+// the position of the feed horn.  The IL position is a compromise that
+// is designed to be visible in both positions.
+/
+// RA-2 Relay Antenna
+@PART[RelayAntenna5]:AFTER[ReStock]:NEEDS[IndicatorLights]
+{
+	!MODEL:HAS[#model[IndicatorLights/Meshes/nubbinLamp]],* { }
+	MODEL
+	{
+		model = IndicatorLights/Meshes/nubbinLamp
+		position = 0, .38, 0
+		scale = 2.0, 2.0, 1
+		rotation = -90, 0, 0
+	}
+}
+
+// RA-15 Relay Antenna
+@PART[RelayAntenna50]:AFTER[ReStock]:NEEDS[IndicatorLights]
+{
+	!MODEL:HAS[#model[IndicatorLights/Meshes/nubbinLamp]],* { }
+	MODEL
+	{
+		model = IndicatorLights/Meshes/nubbinLamp
+		position = 0, 1.125, 0
+		scale = 2, 2, 2.5
+		rotation = -90, 0, 0
+	}
+}
+
+// RA-100 Relay Antenna
+@PART[RelayAntenna100]:AFTER[ReStock]:NEEDS[IndicatorLights]
+{
+	!MODEL:HAS[#model[IndicatorLights/Meshes/nubbinLamp]],* { }
+	MODEL
+	{
+		model = IndicatorLights/Meshes/nubbinLamp
+		position = 0, 1.18, 0 //1.3 was clear abovej
+		scale = 1.5, 1.5, 5
+		rotation = -90, 0, 0
+	}
+
+}
 
 // Communotron 16
 @PART[longAntenna]:AFTER[ReStock]:NEEDS[IndicatorLights]
 {
+	!MODEL:HAS[#model[Squad/Parts/Utility/commsDish16/model]] { }
+	!MODEL:HAS[#model[IndicatorLights/Meshes/nubbinLamp]],* { }
 	MODEL
 	{
 		model = IndicatorLights/Meshes/nubbinLamp
@@ -24,6 +67,7 @@
 // Communotron 16-S
 @PART[SurfAntenna]:AFTER[ReStock]:NEEDS[IndicatorLights]
 {
+	!MODEL:HAS[#model[IndicatorLights/Meshes/squareLamp2]],* { }
 	MODEL
 	{
 		model = IndicatorLights/Meshes/squareLamp2
@@ -36,6 +80,8 @@
 // Communotron 88-88
 @PART[commDish]:AFTER[ReStock]:NEEDS[IndicatorLights]
 {
+	!MODEL:HAS[#model[Squad/Parts/Utility/commDish88-88/model]] { }
+	!MODEL:HAS[#model[IndicatorLights/Meshes/nubbinLamp]],* { }
 	MODEL
 	{
 		model = IndicatorLights/Meshes/nubbinLamp
@@ -48,6 +94,8 @@
 // Communotron DTS-M1
 @PART[mediumDishAntenna]:AFTER[ReStock]:NEEDS[IndicatorLights]
 {
+	!MODEL:HAS[#model[Squad/Parts/Utility/commsAntennaDTS-M1/mediumDishAntenna]] { }
+	!MODEL:HAS[#model[IndicatorLights/Meshes/squareLamp2]],* { }
 	MODEL
 	{
 		model = IndicatorLights/Meshes/squareLamp2
@@ -60,6 +108,7 @@
 // Communotron HG-5 High Gain Antenna
 @PART[HighGainAntenna5]:AFTER[ReStock]:NEEDS[IndicatorLights]
 {
+	!MODEL:HAS[#model[IndicatorLights/Meshes/squareLamp2]],* { }
 	MODEL
 	{
 		model = IndicatorLights/Meshes/squareLamp2
@@ -72,6 +121,7 @@
 // Communotron HG-55
 @PART[HighGainAntenna]:AFTER[ReStock]:NEEDS[IndicatorLights]
 {
+	!MODEL:HAS[#model[IndicatorLights/Meshes/squareLamp2]],* { }
 	MODEL
 	{
 		model = IndicatorLights/Meshes/squareLamp2
@@ -186,13 +236,13 @@
 	{
 		model = ReStock/Assets/Electrical/restock-battery-radial-small-1
 		position = 0.0, 0.0, 0.0
-		scale = 0.5, 0.5, 0.5
+		scale = 1.0, 1.0, 1.0
 		rotation = 0, 0, 0
 	}
 	MODEL
 	{
 		model = IndicatorLights/Meshes/z100lamp
-		scale = 0.35, 0.35, 0.35
+		scale = 0.7, 0.7, 0.7
 		position = 0.021, 0.106, -0.05
 		rotation = 270, 0, 0
 	}
@@ -422,22 +472,29 @@
 	{
 		model = IndicatorLights/Meshes/squareLamp2
 		scale = 0.3, 1, 2
-		position = -0.0125, 0.26, -1.09
-		rotation = 0, 90, 0
+		position = 0.0, 0.25, 1.13
+		rotation = 12, 0, 0
 	}
 	MODEL
 	{
 		model = IndicatorLights/Meshes/squareLamp2
 		scale = 0.3, 1, 2
-		position = 0.946, 0.26, 0.535
-		rotation = 0, -30, 0
+		position = 0.0, 0.26, -1.13
+		rotation = 0, 0, 0
 	}
 	MODEL
 	{
 		model = IndicatorLights/Meshes/squareLamp2
-		scale = 0.3, 1, 2
-		position = -0.946, 0.26, 0.535
-		rotation = 0, 30, 0
+		scale = 2.0, 1, 0.3
+		position = -0.8, 0.25, -0.8
+		rotation = 0, -46.5, 12
+	}
+	MODEL
+	{
+		model = IndicatorLights/Meshes/squareLamp2
+		scale = 2.0, 1, 0.3
+		position = 0.8, 0.25, -0.8
+		rotation = 0, 46.5, -12
 	}
 	MODEL
 	{
@@ -552,33 +609,36 @@
       rotation = 180, 0, 0
     }
     %rescaleFactor = 1
-	MODEL
+	MODEL //left
 	{
 		model = IndicatorLights/Meshes/squareLamp2
-		scale = 1, 1, 0.3
-		position = -0.5331, 0.08, 0
-		rotation = 0, 0, 20
+		scale = 1.5, 1, 0.3
+		position = -0.37696, 0.08, -0.37696
+		rotation = 0, -46.5, 18
 	}
-	MODEL
+
+	MODEL //right
 	{
 		model = IndicatorLights/Meshes/squareLamp2
-		scale = 1, 1, 0.3
-		position = 0.5331, 0.08, 0
-		rotation = 0, 0, -20
+		scale = 1.5, 1, 0.3
+		position = 0.37696, 0.08, -0.37696
+		rotation = 0, 46.5, -18
 	}
-	MODEL
+
+	MODEL //bottom
 	{
 		model = IndicatorLights/Meshes/squareLamp2
-		scale = 0.3, 1, 1
+		scale = 0.3, 1, 1.5
 		position = 0, 0.08, -0.5331
-		rotation = -20, 0, 0
+		rotation = -18, 0, 0
 	}
-	MODEL
+
+	MODEL //top
 	{
 		model = IndicatorLights/Meshes/squareLamp2
-		scale = 0.3, 1, 1
+		scale = 0.3, 1, 1.5
 		position = 0, 0.08, 0.5331
-		rotation = 20, 0, 0
+		rotation = 18, 0, 0
 	}
 
 	MODULE
@@ -659,6 +719,20 @@
 		model = ReStock/Assets/Coupling/restock-docking-0625
 	}
 	%rescaleFactor = 1
+	MODEL
+	{
+		model = IndicatorLights/Meshes/squareLamp2
+		scale = 0.3, 0.6, 0.3
+		position = 0.000, 0.05, 0.275
+		rotation = 40, 0, 0
+	}
+	MODEL
+	{
+		model = IndicatorLights/Meshes/squareLamp2
+		scale = 0.9, 0.6, 0.3
+		position = 0.000, 0.065, 0.255
+		rotation = 40, 0, 0
+	}
 	MODEL
 	{
 		model = IndicatorLights/Meshes/squareLamp2
@@ -854,7 +928,7 @@
 	-MODEL,* {}
 	MODEL
 	{
-		model = ReStock/Assets/Science/restock-sciencebox-radial
+		model = ReStock/Assets/Science/restock-sciencebox-radial-1
 	}
 	MODEL
 	{

--- a/patches/IndicatorLights_ReStock.cfg
+++ b/patches/IndicatorLights_ReStock.cfg
@@ -2,7 +2,12 @@
 // Thanks to UnanimousCoward on the KSP forums for supplying this patch!
 // Mod thread for ReStock:
 // https://forum.kerbalspaceprogram.com/index.php?/topic/182679-17x-restock-revamping-ksps-art-may-10-ksp-17-fixes/
-
+//
+// Many of the light locations defined by the base IL mod for a stock game
+// are poorly placed for ReStock and still need work. The ReStock patch
+// is a work in progress 
+// -Tonka Crash
+//
 //---------------------------------------------------------------------------//
 // Antennas                                                                  //
 //---------------------------------------------------------------------------//
@@ -138,8 +143,13 @@
 // colour of the lamp. Fixing this requires modifying
 // GameData\ReStock\Assets\Electrical\restock-batteries-1-e.dds and
 // restock-batteries-2-e.dds,but the ReStock licence doesn't permit this.
-// Deleting those files will not work. Replacing htme with plain black will work.
-
+//
+// Ideal light location would be to put a IL over the green emissive spot
+// to make it appear active, but original writer of this patch decided to
+// just add lights to mimic stock part locations.  I haven't had time or
+// desire to sort this out for all cases.
+// - Tonka Crash
+//
 // 0.625m battery bank
 @PART[batteryBankMini]:AFTER[ReStock]:NEEDS[IndicatorLights]
 {
@@ -147,9 +157,6 @@
 	MODEL
 	{
 		model = ReStock/Assets/Electrical/restock-battery-0625-1
-		position = 0.0, 0.0, 0.0
-		scale = 1,1,1
-		rotation = 0, 0, 0
 	}
 	MODEL
 	{
@@ -171,9 +178,6 @@
 	MODEL
 	{
 		model = ReStock/Assets/Electrical/restock-battery-125-1
-		position = 0.0, 0.0, 0.0
-		scale = 1,1,1
-		rotation = 0, 0, 0
 	}
 	MODEL
 	{
@@ -203,9 +207,6 @@
 	MODEL
 	{
 		model = ReStock/Assets/Electrical/restock-battery-25-1
-		position = 0.0, 0.0, 0.0
-		scale = 1,1,1
-		rotation = 0, 0, 0
 	}
 	MODEL
 	{
@@ -235,15 +236,14 @@
 	MODEL
 	{
 		model = ReStock/Assets/Electrical/restock-battery-radial-small-1
-		position = 0.0, 0.0, 0.0
-		scale = 1.0, 1.0, 1.0
-		rotation = 0, 0, 0
 	}
 	MODEL
 	{
+	// Cover ReStock Emissive - TonkaCrash
+	// have to keep z100lamp or rewrite more of the stock patch
 		model = IndicatorLights/Meshes/z100lamp
-		scale = 0.7, 0.7, 0.7
-		position = 0.021, 0.106, -0.05
+        scale = 0.75, 0.5, 0.75
+        position = 0.0405,0.211,-.104
 		rotation = 270, 0, 0
 	}
 }
@@ -255,21 +255,18 @@
 	MODEL
 	{
 		model = ReStock/Assets/Electrical/restock-battery-radial-med-1
-		position = 0.0, 0.0, 0.0
-		scale = 1,1,1
-		rotation = 0, 0, 0
 	}
 	MODEL
 	{
 		model = IndicatorLights/Meshes/nubbinLamp
-		position = -0.0225, 0.2725, -0.115
+        position = -0.0228, 0.2725, -0.115
 		scale = 0.58, 0.58, 0.58
 		rotation = 180, 0, 0
 	}
 	MODEL
 	{
 		model = IndicatorLights/Meshes/nubbinLamp
-		position = 0.0225, 0.2725, -0.115
+        position = 0.0228, 0.2725, -0.115
 		scale = 0.58, 0.58, 0.58
 		rotation = 180, 0, 0
 	}
@@ -596,10 +593,18 @@
 	-MODULE[ModuleDockingCrossfeedIndicator]{}
 	-MODULE[ModuleDockingStateIndicator]{}
 
+    // Rotate shielded port so it opens with bilateral symmetry not sure
+    // why Nertea has default placement for this rotatated 90 deg around
+    // ship's longitudinal axis.  It looks sloppy to me.
+    // 
+    // Patch opens 1 down two up because this works best for my most used
+    // pods.  For stock mk1-3 opposite orientation probably works better.
+    // - TonkaCrash
 	MODEL
     {
       model = ReStock/Assets/Coupling/restock-docking-shielded-125-1
-      rotation = 0, 90, 0
+      rotation = 0, 90, 0    // 1 down, two up
+      //rotation = 0, -90, 0 // 1 up, two down
     }
     MODEL
     {
@@ -926,8 +931,13 @@
 		disengageColor = blink(ModuleDockingCrossfeedIndicator, 120, $Off, 1080)
 	}
 }
-
-
+// ReStock+ Grande - Skipped intentionally
+//
+// I've never used this part and don't have a need for it with 
+// my playstyle.  If someone wants it, contribute a patch.
+//
+// - Tonka Crash
+//
 //---------------------------------------------------------------------------//
 // SAS                                                                       //
 //---------------------------------------------------------------------------//
@@ -1132,5 +1142,31 @@
 		scale = 0.3, 2, 0.3
 		position = 0, 0.11416, -0.30133
 		rotation = 0, 180, 90
+    }
+}
+//Sentinel Sensor
+@PART[InfraredTelescope]:AFTER[ReStock]:NEEDS[IndicatorLights]
+{
+    -MODEL,* {}
+    MODEL
+    {
+        model = ReStock/Assets/Science/restock-sentinel-1
+    }
+    MODEL
+    {
+	// Was a ring around the lens, but to avoid obsuring
+	// telescope tube and sensor move to 2nd small indicater 
+        model = IndicatorLights/Meshes/nubbinLamp
+        scale = 1.5, 1.5, 1
+        position = -.30, 1.06, -0.42
+        rotation = -30, 180, 0
 	}
+    // small side lamp, shows science availability
+    MODEL
+    {
+        model = IndicatorLights/Meshes/nubbinLamp
+        scale = 1.5, 1.5, 1
+        position = -.30, 0.96, -0.47
+        rotation = -30, 180, 0
+    }
 }

--- a/patches/IndicatorLights_ReStock.cfg
+++ b/patches/IndicatorLights_ReStock.cfg
@@ -486,15 +486,15 @@
 	{
 		model = IndicatorLights/Meshes/squareLamp2
 		scale = 2.0, 1, 0.3
-		position = -0.8, 0.25, -0.8
-		rotation = 0, -46.5, 12
+		position = -0.8, 0.25, 0.8
+		rotation = 0, 46.5, 12
 	}
 	MODEL
 	{
 		model = IndicatorLights/Meshes/squareLamp2
 		scale = 2.0, 1, 0.3
-		position = 0.8, 0.25, -0.8
-		rotation = 0, 46.5, -12
+		position = 0.8, 0.25, 0.8
+		rotation = 0, -46.5, -12
 	}
 	MODEL
 	{
@@ -613,16 +613,16 @@
 	{
 		model = IndicatorLights/Meshes/squareLamp2
 		scale = 1.5, 1, 0.3
-		position = -0.37696, 0.08, -0.37696
-		rotation = 0, -46.5, 18
+		position = -0.37696, 0.08, 0.37696
+		rotation = 0, 46.5, 18
 	}
 
 	MODEL //right
 	{
 		model = IndicatorLights/Meshes/squareLamp2
 		scale = 1.5, 1, 0.3
-		position = 0.37696, 0.08, -0.37696
-		rotation = 0, 46.5, -18
+		position = 0.37696, 0.08, 0.37696
+		rotation = 0, -46.5, -18
 	}
 
 	MODEL //bottom
@@ -723,15 +723,15 @@
 	{
 		model = IndicatorLights/Meshes/squareLamp2
 		scale = 0.3, 0.6, 0.3
-		position = 0.000, 0.05, 0.275
-		rotation = 40, 0, 0
+		position = 0.000, 0.05, -0.275
+		rotation = -40, 0, 0
 	}
 	MODEL
 	{
 		model = IndicatorLights/Meshes/squareLamp2
 		scale = 0.9, 0.6, 0.3
-		position = 0.000, 0.065, 0.255
-		rotation = 40, 0, 0
+		position = 0.000, 0.065, -0.255
+		rotation = -40, 0, 0
 	}
 	MODEL
 	{

--- a/patches/IndicatorLights_ReStock.cfg
+++ b/patches/IndicatorLights_ReStock.cfg
@@ -17,17 +17,14 @@
 // so both models overlay each other. The simplest fix is to just delete the
 // reduncdant model nodes. -Tonka Crash
 //---------------------------------------------------------------------------//
-@PART[advSasModule]:AFTER[ReStock]	{-MODEL,1 {}}
-@PART[asasmodule1-2]:AFTER[ReStock]	{-MODEL,1 {}}
-@PART[SASBatt_Size2]:AFTER[ReStock]	{-MODEL,1 {}}
-@PART[SASBatt_Size3]:AFTER[ReStock]	{-MODEL,1 {}}
-@PART[SASBatt_Size4]:AFTER[ReStock]	{-MODEL,1 {}}
-@PART[cupola]:AFTER[ReStock]		{-MODEL,2 {}}
-@PART[landerCabinSmall]:AFTER[ReStock]	{-MODEL,1 {}}
-@PART[ISRU]:AFTER[ReStock]		{-MODEL,1 {}}
-@PART[crewCabin]:AFTER[ReStock]		{-MODEL,3 {}}
-@PART[Large_Crewed_Lab]:AFTER[ReStock]	{-MODEL,3 {}}
-@PART[SurfaceScanner]:AFTER[ReStock]	{-MODEL,1 {}}
+@PART[advSasModule]:AFTER[ReStock]:NEEDS[IndicatorLights]	{ !MODEL:HAS[#model[Squad/Parts/Command/inlineAdvancedStabilizer/model]] { } }
+@PART[asasmodule1-2]:AFTER[ReStock]:NEEDS[IndicatorLights]	{ !MODEL:HAS[#model[Squad/Parts/Command/advancedSasModuleLarge/model]] { } }
+@PART[cupola]:AFTER[ReStock]:NEEDS[IndicatorLights]		{ !MODEL:HAS[#model[Squad/Parts/Command/cupola/model]] { } }
+@PART[crewCabin]:AFTER[ReStock]:NEEDS[IndicatorLights]		{ !MODEL:HAS[#model[Squad/Parts/Command/hitchhikerStorageContainer/model]] { } }
+@PART[landerCabinSmall]:AFTER[ReStock]:NEEDS[IndicatorLights]	{ !MODEL:HAS[#model[Squad/Parts/Command/mk1LanderCan/model]] { } }
+@PART[ISRU]:AFTER[ReStock]:NEEDS[IndicatorLights]		{ !MODEL:HAS[#model[Squad/Parts/Resources/ISRU/ISRU]] { } }
+@PART[SurfaceScanner]:AFTER[ReStock]:NEEDS[IndicatorLights]	{ !MODEL:HAS[#model[Squad/Parts/Resources/SurfaceScanner/SurfaceScanner]] { } }
+@PART[Large_Crewed_Lab]:AFTER[ReStock]:NEEDS[IndicatorLights]	{ !MODEL:HAS[#model[Squad/Parts/Science/LargeCrewedLab/large_crewed_lab]] { } }
 //---------------------------------------------------------------------------//
 // Antennas                                                                  //
 //---------------------------------------------------------------------------//
@@ -68,7 +65,7 @@
 	MODEL
 	{
 		model = IndicatorLights/Meshes/nubbinLamp
-		position = 0, 1.18, 0 //1.3 was clear abovej
+		position = 0, 1.18, 0
 		scale = 1.5, 1.5, 5
 		rotation = -90, 0, 0
 	}
@@ -262,8 +259,8 @@
 	// Cover ReStock Emissive - TonkaCrash
 	// have to keep z100lamp or rewrite more of the stock patch
 		model = IndicatorLights/Meshes/z100lamp
-        scale = 0.75, 0.5, 0.75
-        position = 0.0405,0.211,-.104
+		scale = 0.75, 0.5, 0.75
+		position = 0.0405,0.211,-.104
 		rotation = 270, 0, 0
 	}
 }
@@ -279,14 +276,14 @@
 	MODEL
 	{
 		model = IndicatorLights/Meshes/nubbinLamp
-        position = -0.0228, 0.2725, -0.115
+		position = -0.0228, 0.2725, -0.115
 		scale = 0.58, 0.58, 0.58
 		rotation = 180, 0, 0
 	}
 	MODEL
 	{
 		model = IndicatorLights/Meshes/nubbinLamp
-        position = 0.0228, 0.2725, -0.115
+		position = 0.0228, 0.2725, -0.115
 		scale = 0.58, 0.58, 0.58
 		rotation = 180, 0, 0
 	}
@@ -300,6 +297,7 @@
 //Cupola
 @PART[cupola]:AFTER[ReStock]:NEEDS[IndicatorLights]
 {
+	!MODEL:HAS[#model[IndicatorLights/Meshes/squareLamp]],* { }
 	MODEL
 	{
 		model = IndicatorLights/Meshes/squareLamp
@@ -310,41 +308,68 @@
 }
 
 //Hitchhiker
-@PART[crewCabin]:AFTER[zzzzStationParts]:NEEDS[IndicatorLights&ReStock]
+@PART[crewCabin]:AFTER[ReStock]:NEEDS[IndicatorLights]
 {
-  MODEL
-  {
-	  model = IndicatorLights/Meshes/nubbinLamp
-	  scale = 0.7, 0.7, 0.9
-	  position = 0.37, 0.16, -1.185
-	  rotation = 0, 155, 0
-  }
-  MODEL
-  {
-	  model = IndicatorLights/Meshes/nubbinLamp
-	  scale = 0.7, 0.7, 0.9
-	  position = 0.37, 0.06, -1.185
-	  rotation = 0, 155, 0
-  }
-  MODEL
-  {
-	  model = IndicatorLights/Meshes/nubbinLamp
-	  scale = 0.7, 0.7, 0.9
-	  position = 0.37, -0.04, -1.185
-	  rotation = 0, 155, 0
-  }
-  MODEL
-  {
-	  model = IndicatorLights/Meshes/nubbinLamp
-	  scale = 0.7, 0.7, 0.9
-	  position = 0.37, -0.14, -1.185
-	  rotation = 0, 155, 0
-  }
+	!MODEL:HAS[#model[IndicatorLights/Meshes/nubbinLamp]],* { }
+	!MODULE[ModuleControllableEmmissive] {}
+	MODEL
+	{
+	        model = IndicatorLights/Meshes/squareLamp
+	        position = -0.1, 0.215, -1.28
+	        scale = 1, 0.25, 0.5
+	        rotation = 0, 180, 0
+	}
+	MODEL
+	{
+	        model = IndicatorLights/Meshes/squareLamp
+	        position = 0.08, 0.215, -1.28
+	        scale = 1, 0.25, 0.5
+	        rotation = 0, 180, 0
+	}
+	MODEL
+	{
+	        model = IndicatorLights/Meshes/squareLamp
+	        position = -0.1, -0.215, -1.28
+	        scale = 1, 0.25, 0.5
+	        rotation = 0, 180, 0
+	}
+	MODEL
+	{
+	        model = IndicatorLights/Meshes/squareLamp
+	        position = 0.08, -0.215, -1.28
+	        scale = 1, 0.25, 0.5
+	        rotation = 0, 180, 0
+	}
+	MODULE
+	{
+		name = ModuleControllableEmissive
+		target = IndicatorLights/Meshes/squareLamp:0
+		emissiveName = indicator0
+	}
+	MODULE
+	{
+		name = ModuleControllableEmissive
+		target = IndicatorLights/Meshes/squareLamp:1
+		emissiveName = indicator1
+	}
+	MODULE
+	{
+		name = ModuleControllableEmissive
+		target = IndicatorLights/Meshes/squareLamp:2
+		emissiveName = indicator2
+	}
+	MODULE
+	{
+		name = ModuleControllableEmissive
+		target = IndicatorLights/Meshes/squareLamp:3
+		emissiveName = indicator3
+	}
 }
 
 //Mk1-3 pod
 @PART[mk1-3pod]:AFTER[ReStock]:NEEDS[IndicatorLights]
 {
+	!MODEL:HAS[#model[IndicatorLights/Meshes/nubbinLamp]],* { }
 	MODEL
 	{
 		model = IndicatorLights/Meshes/nubbinLamp
@@ -371,6 +396,7 @@
 //Mk1 Lander Can
 @PART[landerCabinSmall]:AFTER[ReStock]:NEEDS[IndicatorLights]
 {
+	!MODEL:HAS[#model[IndicatorLights/Meshes/squareLamp]],* { }
 	MODEL
 	{
 		model = IndicatorLights/Meshes/squareLamp
@@ -383,6 +409,7 @@
 //Mk1 Pod (v2)
 @PART[mk1pod_v2]:AFTER[ReStock]:NEEDS[IndicatorLights]
 {
+	!MODEL:HAS[#model[IndicatorLights/Meshes/squareLamp]],* { }
 	MODEL
 	{
 		model = IndicatorLights/Meshes/squareLamp
@@ -395,11 +422,12 @@
 //Mk2 lander can (V2)
 @PART[mk2LanderCabin_v2]:AFTER[ReStock]:NEEDS[IndicatorLights]
 {
+	!MODEL:HAS[#model[IndicatorLights/Meshes/squareLamp]],* { }
 	MODEL
 	{
 		model = IndicatorLights/Meshes/squareLamp
-		scale = 0.24, 1, 0.5
-		position = -0.185, 0.325, -1.378
+	        scale = 1, 0.25, 0.5
+		position = 0.0, 0.365, -1.378
 		rotation = 0, 180, 0
 	}
 	MODEL
@@ -407,13 +435,13 @@
 		model = IndicatorLights/Meshes/squareLamp
 		scale = 0.25, 1, 0.5
 		position = -0.245, 0.745, 0
-		rotation = -90, 0, 0
+	        rotation = 0, 180, 0
 	}
 	MODEL
 	{
 		model = IndicatorLights/Meshes/squareLamp
-		scale = 0.25, 1, 0.5
-		position = 0.17, 0.325, -1.378
+	        scale = 1, 0.25, 0.5
+		position = 0.0, -0.065, -1.378
 		rotation = 0, 180, 0
 	}
 	MODEL
@@ -421,13 +449,14 @@
 		model = IndicatorLights/Meshes/squareLamp
 		scale = 0.25, 1, 0.5
 		position = 0.245, 0.745, 0
-		rotation = -90, 0, 0
+	        rotation = 0, 180, 0
 	}
 }
 
 //Large science lab
 @PART[Large_Crewed_Lab]:AFTER[ReStock]:NEEDS[IndicatorLights]
 {
+	!MODEL:HAS[#model[IndicatorLights/Meshes/squareLamp]],* { }
 	MODEL
 	{
 		model = IndicatorLights/Meshes/squareLamp
@@ -528,7 +557,7 @@
 		rotation = 0, 60, 90
 	}
 	MODEL
-	{+
+	{
 		model = IndicatorLights/Meshes/squareLamp
 		scale = 0.3, 1.6, 1
 		position = -1.117, 0.18, 0.6475
@@ -951,13 +980,8 @@
 		disengageColor = blink(ModuleDockingCrossfeedIndicator, 120, $Off, 1080)
 	}
 }
-// ReStock+ Grande - Skipped intentionally
-//
-// I've never used this part and don't have a need for it with 
-// my playstyle.  If someone wants it, contribute a patch.
-//
-// - Tonka Crash
-//
+
+
 //---------------------------------------------------------------------------//
 // SAS                                                                       //
 //---------------------------------------------------------------------------//

--- a/patches/IndicatorLights_ReStock.cfg
+++ b/patches/IndicatorLights_ReStock.cfg
@@ -586,7 +586,123 @@
 		disengageColor = blink(ModuleDockingCrossfeedIndicator, 120, $Off, 1080)
 	}
 }
+//Shielded docking port
+@PART[dockingPort1]:AFTER[ReStock]:NEEDS[IndicatorLights]
+{
+	-MODEL,* {}
+	-MODULE[ModuleColorChanger]{}
+	-MODULE[ModuleControllableEmissive]{}
+	-MODULE[ModuleToggleLED]{}
+	-MODULE[ModuleDockingCrossfeedIndicator]{}
+	-MODULE[ModuleDockingStateIndicator]{}
 
+	MODEL
+    {
+      model = ReStock/Assets/Coupling/restock-docking-shielded-125-1
+      rotation = 0, 90, 0
+    }
+    MODEL
+    {
+      model = ReStock/Assets/Command/restock-hatch-common-round-white-1
+      position = 0.0, -0.072, 0.0
+      scale = 0.908,0.908,0.908
+      rotation = 180, 0, 0
+    }
+    %rescaleFactor = 1
+	MODEL //left
+	{
+		model = IndicatorLights/Meshes/squareLamp2
+		scale = 0.7, 1, 0.3
+		position = -0.24395, 0.271, 0.24395
+		rotation = 0, 46.5, 0
+	}
+
+	MODEL //right
+	{
+		model = IndicatorLights/Meshes/squareLamp2
+		scale = 0.7, 1, 0.3
+		position = 0.24395, 0.271, 0.24395
+		rotation = 0, -46.5, 0
+	}
+
+	MODEL //bottom
+	{
+		model = IndicatorLights/Meshes/squareLamp2
+		scale = 0.3, 1, 0.7
+		position = 0, 0.271, -0.35
+		rotation = 0, 0, 0
+	}
+
+	MODEL //top
+	{
+		model = IndicatorLights/Meshes/squareLamp2
+		scale = 0.3, 1, 0.7
+		position = 0, 0.271, 0.345
+		rotation = 0, 0, 0
+	}
+
+	MODULE
+	{
+		name = ModuleColorChanger
+		shaderProperty = _EmissiveColor
+		animRate = 0.8
+		animState = false
+		useRate = true
+		toggleInEditor = true
+		toggleInFlight = true
+		toggleInFlight = true
+		unfocusedRange = 5
+		toggleName = #autoLOC_502011 //#autoLOC_502011 = Toggle Lights
+		eventOnName = #autoLOC_502012 //#autoLOC_502012 = Lights On
+		eventOffName = #autoLOC_502013 //#autoLOC_502013 = Lights Off
+		toggleAction = True
+		defaultActionGroup = Light
+		redCurve
+		{
+			key = 0 0 0 3
+			key = 1 1 0 0
+		}
+		greenCurve
+		{
+			key = 0 0 0 1
+			key = 1 1 1 0
+		}
+		blueCurve
+		{
+			key = 0 0 0 0
+			key = 1 0.7 1.5 0
+		}
+		alphaCurve
+		{
+			key = 0 1
+		}
+	}
+	MODULE
+	{
+		name = ModuleControllableEmissive
+		target = IndicatorLights/Meshes/squareLamp2
+		emissiveName = indicator
+	}
+	MODULE
+	{
+		name = ModuleToggleLED
+		activeColor = ModuleDockingCrossfeedIndicator
+		inactiveColor = $Off
+		defaultActionGroup = Light
+	}
+	MODULE
+	{
+	name = ModuleDockingCrossfeedIndicator
+	}
+	MODULE
+	{
+		name = ModuleDockingStateIndicator
+		emissiveName = indicator
+		readyColor = ModuleToggleLED
+		acquireColor = blink(ModuleDockingCrossfeedIndicator, 100, $Off, 100)
+		disengageColor = blink(ModuleDockingCrossfeedIndicator, 120, $Off, 1080)
+	}
+}
 //Medium docking port
 @PART[dockingPort2]:AFTER[ReStock]:NEEDS[IndicatorLights]
 {

--- a/patches/IndicatorLights_ReStock.cfg
+++ b/patches/IndicatorLights_ReStock.cfg
@@ -9,12 +9,32 @@
 // -Tonka Crash
 //
 //---------------------------------------------------------------------------//
+// Fix duplicate models where IL added a model based on the original parts
+// having a mesh=model syntax.  Restock does this too, so parts end up with
+// duplicate models for the basic part.  Sometimes it's not obvious if the
+// stock part was not whitelisted. But this will throw an error since the 
+// model was removed by ReStock. The worst case is the part was whitelisted,
+// so both models overlay each other. The simplest fix is to just delete the
+// reduncdant model nodes. -Tonka Crash
+//---------------------------------------------------------------------------//
+@PART[advSasModule]:AFTER[ReStock]	{-MODEL,1 {}}
+@PART[asasmodule1-2]:AFTER[ReStock]	{-MODEL,1 {}}
+@PART[SASBatt_Size2]:AFTER[ReStock]	{-MODEL,1 {}}
+@PART[SASBatt_Size3]:AFTER[ReStock]	{-MODEL,1 {}}
+@PART[SASBatt_Size4]:AFTER[ReStock]	{-MODEL,1 {}}
+@PART[cupola]:AFTER[ReStock]		{-MODEL,2 {}}
+@PART[landerCabinSmall]:AFTER[ReStock]	{-MODEL,1 {}}
+@PART[ISRU]:AFTER[ReStock]		{-MODEL,1 {}}
+@PART[crewCabin]:AFTER[ReStock]		{-MODEL,3 {}}
+@PART[Large_Crewed_Lab]:AFTER[ReStock]	{-MODEL,3 {}}
+@PART[SurfaceScanner]:AFTER[ReStock]	{-MODEL,1 {}}
+//---------------------------------------------------------------------------//
 // Antennas                                                                  //
 //---------------------------------------------------------------------------//
 // RA-2, RA-15 and RA-100 Relay Antennas have model variants that change
 // the position of the feed horn.  The IL position is a compromise that
 // is designed to be visible in both positions.
-/
+//
 // RA-2 Relay Antenna
 @PART[RelayAntenna5]:AFTER[ReStock]:NEEDS[IndicatorLights]
 {


### PR DESCRIPTION
ReStock docking ports are symmetric and provide no indication for their orientation.  Changed lights so that they form an arrow pointing to "Up" orientation of port. "Up" is defined as dorsal side of craft or hatch side for stock capsules. 